### PR TITLE
Fix page title typo

### DIFF
--- a/apps/joplin-batch-web/src/pages/fixFileExtendsion/FixFileExtensionPage.tsx
+++ b/apps/joplin-batch-web/src/pages/fixFileExtendsion/FixFileExtensionPage.tsx
@@ -56,7 +56,7 @@ export const FixFileExtensionPage: React.FC = () => {
 
   return (
     <Card
-      title={i18n.t('unusedResource.title')}
+      title={i18n.t('fixFileExtension.title')}
       extra={
         <Space>
           <Button onClick={fetch}>{i18n.t('common.action.check')}</Button>


### PR DESCRIPTION
should be the title of fix file extension, not remove unused resources.