### PR TITLE
feat: replace,  Added option to preserve updated time

### DIFF
--- a/apps/joplin-batch-web/src/i18n/en.json
+++ b/apps/joplin-batch-web/src/i18n/en.json
@@ -36,6 +36,7 @@
   "replace.title": "Search and Replace",
   "replace.form.keyword": "Search keyword",
   "replace.form.replaceText": "Replaced Text",
+  "replace.form.keepUpdatedTime": "Preserve note(s) last updated time",
   "replace.action.search": "Search",
   "replace.action.replace": "Replace",
   "replace.action.preview": "Preview",

--- a/apps/joplin-batch-web/src/i18n/zhCN.json
+++ b/apps/joplin-batch-web/src/i18n/zhCN.json
@@ -36,6 +36,7 @@
   "replace.title": "搜索并替换",
   "replace.form.keyword": "搜索关键字",
   "replace.form.replaceText": "替换的文本",
+  "replace.form.keepUpdatedTime": "保留笔记上次更新时间",
   "replace.action.search": "搜索",
   "replace.action.replace": "替换",
   "replace.action.preview": "预览",


### PR DESCRIPTION
## What
This PR adds and the possibility to keep updated time on a note when doing find and replace.

## Why
I needed this functionality to replace old Evernote links with markdown links. When I did a large batch replace all my (very-)old notes suddenly got new updated time, which is a problem when using "last updated" as sorting.
