### PR TITLE
fix: note name clashes and loss of data

### DIFF
--- a/apps/joplin-vscode-plugin/src/service/JoplinNoteCommandService.ts
+++ b/apps/joplin-vscode-plugin/src/service/JoplinNoteCommandService.ts
@@ -218,8 +218,10 @@ export class JoplinNoteCommandService {
       return
     }
     const tempNoteDirPath = path.resolve(GlobalContext.context.globalStorageUri.fsPath, '.tempNote')
-    const filename = item.title + (GlobalContext.openNoteMap.get(item.title) ? item.id : '')
-    const tempNotePath = path.resolve(tempNoteDirPath, filenamify(`${filename}.md`))
+    let tempNotePath = path.resolve(tempNoteDirPath, filenamify(`${item.title}.md`))
+    if (GlobalContext.openNoteMap.has(tempNotePath)) {
+      tempNotePath = path.resolve(tempNoteDirPath, filenamify(`${item.title} (${item.id}).md`))
+    }
     const note = await noteApi.get(item.id, ['body', 'title'])
     const content = (note.title.startsWith('# ') ? '' : '# ') + note.title + '\n\n' + note.body
     await writeFile(tempNotePath, content)


### PR DESCRIPTION
Fixes [#49](https://github.com/rxliuli/joplin-utils/issues/49#issue-1284467172)

## Solution

Concatenates the note id to the filename to avoid clashes and loss of data.

![First test1 file](https://i.postimg.cc/GhPWgfRM/vmware-20221101-143241-250.png)

![Second test1 file](https://i.postimg.cc/BQ3yFCF2/vmware-20221101-143253-447.png)