### PR TITLE
test: optional URL in .env.local to override 'http://127.0.0.1:27583'

### DIFF
--- a/packages/joplin-api/src/api/__tests__/api.test.ts
+++ b/packages/joplin-api/src/api/__tests__/api.test.ts
@@ -47,9 +47,9 @@ describe('api test', function () {
     config.token = '1'
     expect(noteApi.getConfig().token).toBe('1')
   })
-  it('测试使用 127.0.0.1', async () => {
+  it('测试使用 baseUrl', async () => {
     const api = new JoplinApiGenerator()
-    api.baseUrl = 'http://127.0.0.1:27583/'
+    api.baseUrl = config.baseUrl
     api.token = config.token
     expect(await api.joplinApi.ping()).toBeTruthy()
   })

--- a/packages/joplin-api/src/util/setupTestEnv.ts
+++ b/packages/joplin-api/src/util/setupTestEnv.ts
@@ -4,8 +4,8 @@ import { parse } from 'envfile'
 import * as path from 'path'
 import { findParent } from './findParent'
 
+// Read Joplin API 'TOKEN' (and optional 'URL') from .env.local file
 export async function setupTestEnv() {
-  config.baseUrl = 'http://127.0.0.1:27583'
   const dirPath = await findParent(__dirname, (item) => pathExists(path.resolve(item, 'package.json')))
   const envPath = path.resolve(dirPath!, '.env.local')
   if (!(await pathExists(envPath))) {
@@ -13,5 +13,6 @@ export async function setupTestEnv() {
   }
   const env = await readFile(envPath, 'utf8')
 
+  config.baseUrl = parse(env).URL || 'http://127.0.0.1:27583'
   config.token = parse(env).TOKEN!
 }


### PR DESCRIPTION
This is just a simple change to allow reading the URL of the Joplin API from the `.env.local` file as URL along with the TOKEN value.
If URL is not provided, it defaults to the previous hard-coded value of `http://127.0.0.1:27583`

This change makes it possible to run the joplin-api unit tests against a Joplin Clipper Server running on an arbitrary port, or even remotely.